### PR TITLE
feat: upgrade rancher-cli to use latest kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM blackholegalaxy/rancher-cli:2.3.2
+FROM blackholegalaxy/rancher-cli:2.3.2-3
 LABEL maintainer="exalif"
 
 ENV NODE_ENV production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exalif-cli",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Exalif CLI to deploy on Rancher 2 and do other magic stuff",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
`2.3.2-3` version of custom rancher-CLI includes kubectl `1.17.4`