### PR TITLE
fix(exec): escape kubectl executed command

### DIFF
--- a/lib/rancher/exec.js
+++ b/lib/rancher/exec.js
@@ -62,6 +62,7 @@ const rancherExecMixin = superclass => class extends superclass {
       podName,
       '-n',
       this.namespace,
+      '--',
       ...this.execCommand.split(' ')
     ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exalif-cli",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Exalif CLI to deploy on Rancher 2 and do other magic stuff",
   "main": "app.js",
   "scripts": {

--- a/tests/rancher/exec.spec.js
+++ b/tests/rancher/exec.spec.js
@@ -176,6 +176,7 @@ describe('RancherSingleServiceUtils class', () => {
       RANCHER_INSTANCE_MOCK.service,
       '-n',
       NAMESPACE,
+      '--',
       ...RANCHER_INSTANCE_MOCK.execCommand.split(' ')
     ];
 


### PR DESCRIPTION
We now escape kubectl commands. So we can pass hyphens arguments in these commands. Ex:
`exec on someservice of namespace --execCommand="gitlab-ctl registry-garbage-collect -m"`